### PR TITLE
Fixed command's description

### DIFF
--- a/source/Scaffolder/Commands/CommandCommand.php
+++ b/source/Scaffolder/Commands/CommandCommand.php
@@ -26,12 +26,12 @@ class CommandCommand extends AbstractCommand
     const NAME        = 'create:command';
     const DESCRIPTION = 'Create command declaration';
     const ARGUMENTS   = [
-        ['name', InputArgument::REQUIRED, 'Controller name'],
+        ['name', InputArgument::REQUIRED, 'Command name'],
         ['alias', InputArgument::OPTIONAL, 'Command id/alias'],
     ];
 
     /**
-     * Create controller declaration.
+     * Create command declaration.
      */
     public function perform()
     {


### PR DESCRIPTION
When i run the help command for `create:command`, i get a wrong description.. It says create controller instead of command