### PR TITLE
Fix config path

### DIFF
--- a/src/Bootloader/ScaffolderBootloader.php
+++ b/src/Bootloader/ScaffolderBootloader.php
@@ -95,7 +95,7 @@ class ScaffolderBootloader extends Bootloader
                     'postfix'   => 'Config',
                     'class'     => Declaration\ConfigDeclaration::class,
                     'options'   => [
-                        'directory' => directory('app') . 'config/',
+                        'directory' => directory('config'),
                     ]
                 ],
                 'controller' => [


### PR DESCRIPTION
There is a special 'config' key in the system. In case of replacing the file structure in the project with a different one than the default one, forcing the path app/config causes problems (the configuration is not merged with user files by default, so the whole 'declaration' section must be repeated in scaffolding.php).