### PR TITLE
Improve composer package discoverability with tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "type": "module",
   "license": "MIT",
   "description": "Spiral, Code Scaffolding module",
+  "keywords": ["scaffolding"],
   "authors": [
     {
       "name": "Anton Titov / Wolfy-J",


### PR DESCRIPTION
Same tag used by:
- nette/php-generator https://github.com/nette/php-generator/blob/6a55356f2695d2153c911fe782f7fa4fe713b5d9/composer.json#L4
- symfony/maker-bundle https://github.com/symfony/maker-bundle/blob/da629093c7bf9abd9a6a0f232a43bbb1b88de68d/composer.json#L7